### PR TITLE
DM-23983: Cannot apply crosstalk in Gen 3 DECam processing

### DIFF
--- a/rawData/cpCalib/calibRegistry.sqlite3
+++ b/rawData/cpCalib/calibRegistry.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:59e36f34882665bb1c8687aad218a9b10e476e42bdab7405fb7880bf47c0cdcd
+oid sha256:cea493385cd84ee2d193169c4df444fa51a2bbccb65f7b79ed11f6556dbfba14
 size 143360

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-001.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-001.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:440cc461b7d0fed3fc92c21cb61ddc7ba31b9c965d489024b9f81a877fd6c452
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-002.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-002.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5e2feab9b60b4ee2e84c789160e3aee0b628524238d6f07e4352c02fe6900e8
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-003.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-003.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10c5f01cfd37a0cc3796bfff7fb304b7cacbdd02ff8816385e2875cd38e90742
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-004.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-004.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04d72082f683bf78d83332b6447cd489d759d1b74db8f558ad690592e5ce4f0f
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-005.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-005.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6599da9dee68224e4b1f58c2e52949c57ad775b6bdd2ca671c39ee256d2aa67b
+size 8640

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-006.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-006.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2943e9aa8a62191cf1b172d4dfef30a0efe3361dc3b8773ad382375e5f02068
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-007.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-007.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d517c857ddb74c3ccb9d403345cbde08c1838af244224d4840c0b51a49260912
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-008.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-008.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:944aa7f9fbc353f5213478a5260afcb085e2d766917302ef6dc451e8dc0ab421
+size 8640

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-009.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-009.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b343006584137a7ba62b04e57f01e131eae4b08e7e1b50b1acac63a849c0db62
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-010.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-010.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98e6764978c073b013d7e838722053e9ea1bc84dc482cdfdeb5d8d0d771134ff
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-011.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-011.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3bff03d06e6ee9a2ad5a665d0c27c6983ea94c4f8fe9c60af0940943d53a1f7
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-012.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-012.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7db59272f5b3205c44f196e7e5372052ac1e45e8d4858caecdedbb14b5b60108
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-013.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-013.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db9016915ea4e5e7f5e50751dcd3438181a8be43851cd0dcdabbbd7303edfcfb
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-014.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-014.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28e490f31d3eb2eae531fd77029c470d5ae21d73e899ef5252b8e1820efa80f1
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-015.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-015.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc4b6b6f64c9df5ade322862395236a57ce05f19437aa0c5018d9d21bf9efa9f
+size 8640

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-016.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-016.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c17adfb74f25e2dfab7a5e89048ad6037583c4a61f5248b095e58842e3343ea
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-017.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-017.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:079f90bfeaf5bed8c2f7375913e7ecc9c5fd64b06c66cf431d63c59d7790f6d8
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-018.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-018.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0524979849d7e638e58aa1bab417f0bb119f8bdac1464b53533134138b0c8e02
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-019.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-019.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4ac272eb7ca69a219707bc8e0b21a27cc093703c7174a75b0a9a7e9eaea6230
+size 8640

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-020.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-020.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7cec56dd80968151c483bafd6071ffa52a735654f339e281ee9416646bb4e87
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-021.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-021.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ffe530ee3d49ab1487c7d19dbda28b01a89fec6b9888056b90e7ab77d690651
+size 8640

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-022.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-022.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38d614f21f769fa681907e53dc8e0b83960addaae67e9aaaaf18a447a6c64d16
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-023.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-023.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e75707d7a631849a5578a7ab986b742ba4eda441fe9cab02e9c92681ee756e23
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-024.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-024.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44ff8334d588583f2e3ffd773a03b001fa8f876300bdc3479ac38fb0ffa3b427
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-025.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-025.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25dfbbeba855fe1ad187f32ef7619f29996946919f78c812ef9acb32c0ffe37f
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-026.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-026.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77c40301e9a65a987003eaf86bd0613b9e3fa92915ecb7fb086a893e512029c8
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-027.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-027.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78ccea27646a198d3b8f57b69d12e6b11ea147b26707070a4e7e477cd2796c09
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-028.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-028.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3afa5a1bc4e4c75473529fbde54a7e24bd87a36a4be307655404ab934af2f713
+size 8640

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-029.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-029.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22f816270eb1008a8ef1b717d64b8edafb186274a9846a56d73999f81999ae5a
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-030.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-030.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:000843fec696ad8be03242e65ba5b197aa1b050a9eba8e1823d4d0d7ba4223f3
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-031.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-031.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a0914fe5ab178b52920d42ea3a374fffb7985cd86e9570953c0417d924c4dbf
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-032.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-032.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d386e8bf2eae04dcc546d40e6e136e306f3fc9d543f7723c52bbc5261a336c0
+size 8640

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-033.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-033.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16217d28484eb11405d13579510a6779635ce7ab2db90f8b9c90add84fe75ed1
+size 8640

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-034.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-034.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b09b608911c76c27f8fe89c89630be9a1675c7c89f07b7d5126d1c2ce2e1f17
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-035.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-035.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b835fa291d38662d5325699b10837da6ac14faccf29731cb563fd7ddb831c80
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-036.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-036.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6957b05ff27ffb84e0d77cd735e23e22b536d8d63204945e7269f1964a0e7655
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-037.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-037.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:518f8928835c6f4fb616cf2fec934394f68aaf48c703be2502e5756be2b1cc40
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-038.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-038.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d40448c137fe338c5e2b3a6e929bd7d7c4c5eaec1c2786d950cb19bcd89a0d6
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-039.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-039.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ba6ecf2118c0578cedeaf46694dec58042cb37573640af630e139a436d76504
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-040.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-040.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59924648c605ab3d0bb958a8040bab33457601c755129da2071fbcb611b92f5e
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-041.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-041.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef39633808ada4b2e99ac688e5d5ec109053797d615f40cdebf5d65860429a37
+size 8640

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-042.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-042.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a54e45a80ca2d56b1ae614a1bbc324ca798cf2621ef215ced4519e6cf8cf6f23
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-043.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-043.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89d90410e6fa7a8285a43e9bf5c2463f1dd6f69714205f0d401c3ea8df84e8ee
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-044.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-044.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04399b89bd3ed565aac803c433df765b343d46e0ff766f30fb59a01dfaf8e100
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-045.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-045.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4923fc0e36fdb91f76aaedc3f29f7522f4936c6109a2937f405ef535ccc4899
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-046.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-046.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f60a4370f35dc10dc9300f2304b899e71a51e9f4771080c8361194a0043af39
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-047.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-047.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61d401bb4216b2dd0051100a979971d64d451667ed4d865219aed2fadb2910bb
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-048.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-048.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63438c4dbebcd35a6aa753e2077cfb6c50b83491e7e7eab7cfb463d4b4b717f8
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-049.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-049.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f60c4e436eb5ecd6c4f762cba2ac888abc6cebd49d73642d6953549c142a559c
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-050.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-050.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f07bbf2a3f0bb2a09ec45556353e0d3395b70b97ff0acaa748354e09d9f8559f
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-051.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-051.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6034955cd405f4b1df16987d1d3b6335d5ec022641dc37f38c9c26a4e73ace3
+size 8640

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-052.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-052.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:770b1adf2c39c4e1b1d6a85bb2eff1ea547485a2c23e8034e76a0df846101f88
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-053.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-053.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f348c6a796d1b2cc2c737713aecc5d6449a9c3469733f367187a8c647a65c35
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-054.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-054.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f2421083230a9a1a41b0d19d36c2ea15b91f51a63904578eb52a928bd446c17
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-055.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-055.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05ddeb86ab4f10ad580b0aa1c67b1316b1b7845923972304d34535da3e45e4cc
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-056.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-056.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4621542385706ad9c7c7793b49226ae2923a0d4f2595808aedd2aae64a2c33f9
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-057.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-057.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9269eb7812d6363226a4354b0d03f8df3c167f17ac5af77a7e35a1ae2d6eac3d
+size 8640

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-058.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-058.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:987ec6700d6da8d41e3db232bdf26267be5b2cd8daf90b8f78021440e0141595
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-059.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-059.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c17443bd9add7419d5be3dc71631b3f3eaf57ad74045d8b79176024783cb4367
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-060.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-060.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c034b9d4cc156eadccf03bedfada0c9e5eba72a8a3b9f5ffe23bbb7b88d6be32
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-061.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-061.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7d448948606ec5eb99bf13df1bce5be21c63fdc1e18b69375b16e0ed688b2b3
+size 14400

--- a/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-062.fits
+++ b/rawData/cpCalib/crosstalk/1970-01-01T00:00:00/crosstalk-1970-01-01T00:00:00-062.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0bfa82219ee0b3f82294cf568de2d6437b605949cacc9ff4ee464214689e3d1f
+size 14400


### PR DESCRIPTION
Add new-style crosstalk tables.